### PR TITLE
Fix `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ install-for-dev:
 	source venv/bin/activate && pip install -e .
 
 test:
-	source venv/bin/activate && pytest
+	source venv/bin/activate && pip install -e . && pytest


### PR DESCRIPTION
I followed instructions from the `README.md`. Tests require local installation, due to the package structure using `src` folder. Unless you ran `make install-for-dev` before running `make test`, the latter will fail.